### PR TITLE
feat(ci): Add RPM package; bump actions; clean unused step; add manual trigger

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -4,6 +4,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -26,27 +27,22 @@ jobs:
             artifact_path: |
               dist/*.AppImage
               dist/*.deb
+              dist/*.rpm
         node-version: [18]
 
     runs-on: ${{ matrix.config.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Install Linux dependencies
-        if: matrix.config.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y rpm
 
       - name: Build
         env:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -51,6 +51,10 @@ linux:
       arch:
         - x64
         - arm64
+    - target: rpm
+      arch:
+        - x64
+        - arm64
   publish: null
 
 extraMetadata:


### PR DESCRIPTION
## Summary
* Add RPM package
* Add `workflow_dispatch:` for manually trigger
* Bump `actions/checkout` to v4
* Bump `actions/setup-node` to v4

## Test
* Able to start the program on  Distrobox with Fedora 41 container

Note: Install software to `/opt` is a **bad ideas**, this place should install softwares that are **not** managed by package managers, though it won't cause problems most of times, but will make this software not installable on Fedora Atomic based systems(It should works, but installing to `/opt` continuously causing problems), though the more recommended way to install GUI softwares is using Flatpak, but having more options are always great.

But....I can't find any documentation about changing install path for the `electron-builder`, so maybe just focused on Flatpak.

Related:
https://discussion.fedoraproject.org/t/will-semanage-fcontext-and-restorecon-safe-to-run-when-selinux-disabled-during-atomic-custom-image-build-and-others/139943


## Suggestion for Auto startup on Linux
Check what 地牛 Wake Up! did

```
cat ~/.config/autostart/wake_up.appimage.desktop

[Desktop Entry]
Type=Application
Version=1.0
Name=wake_up.appimage
Comment=wake_up.appimagestartup script
Exec=/var/home/xlion/AppImages/wake_up.appimage --hidden
StartupNotify=false
Terminal=false% 
```
Same method will also works on both flatpak packages or installing to host systems, just ensure the path is right.

